### PR TITLE
fix bitrate metadata information 

### DIFF
--- a/ngx_rtmp_cmd_module.h
+++ b/ngx_rtmp_cmd_module.h
@@ -14,8 +14,8 @@
 #include "ngx_rtmp.h"
 
 
-#define NGX_RTMP_MAX_NAME           256
-#define NGX_RTMP_MAX_URL            256
+#define NGX_RTMP_MAX_NAME           2048
+#define NGX_RTMP_MAX_URL            4096
 #define NGX_RTMP_MAX_ARGS           NGX_RTMP_MAX_NAME
 
 

--- a/ngx_rtmp_codec_module.c
+++ b/ngx_rtmp_codec_module.c
@@ -839,9 +839,17 @@ ngx_rtmp_codec_meta_data(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
 
     ngx_memzero(&v, sizeof(v));
 
-    /* use -1 as a sign of unchanged data;
-     * 0 is a valid value for uncompressed audio */
+    /* use -1 as a sign of unchanged data */
+    v.width = -1;
+    v.height = -1;
+    v.duration = -1;
+    v.frame_rate = -1;
+    v.video_data_rate = -1;
+    v.video_codec_id_n = -1;
+    v.audio_data_rate = -1;
     v.audio_codec_id_n = -1;
+    v.profile[0] = '\0';
+    v.level[0] = '\0';
 
     /* FFmpeg sends a string in front of actal metadata; ignore it */
     skip = !(in->buf->last > in->buf->pos
@@ -854,18 +862,17 @@ ngx_rtmp_codec_meta_data(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
         return NGX_OK;
     }
 
-    ctx->width = (ngx_uint_t) v.width;
-    ctx->height = (ngx_uint_t) v.height;
-    ctx->duration = (ngx_uint_t) v.duration;
-    ctx->frame_rate = (ngx_uint_t) v.frame_rate;
-    ctx->video_data_rate = (ngx_uint_t) v.video_data_rate;
-    ctx->video_codec_id = (ngx_uint_t) v.video_codec_id_n;
-    ctx->audio_data_rate = (ngx_uint_t) v.audio_data_rate;
-    ctx->audio_codec_id = (v.audio_codec_id_n == -1
-            ? 0 : v.audio_codec_id_n == 0
+    if (v.width != -1) ctx->width = (ngx_uint_t) v.width;
+    if (v.height != -1) ctx->height = (ngx_uint_t) v.height;
+    if (v.duration != -1) ctx->duration = (ngx_uint_t) v.duration;
+    if (v.frame_rate != -1) ctx->frame_rate = (ngx_uint_t) v.frame_rate;
+    if (v.video_data_rate != -1) ctx->video_data_rate = (ngx_uint_t) v.video_data_rate;
+    if (v.video_codec_id_n != -1) ctx->video_codec_id = (ngx_uint_t) v.video_codec_id_n;
+    if (v.audio_data_rate != -1) ctx->audio_data_rate = (ngx_uint_t) v.audio_data_rate;
+    if (v.audio_codec_id_n != -1) ctx->audio_codec_id = (v.audio_codec_id_n == 0
             ? NGX_RTMP_AUDIO_UNCOMPRESSED : (ngx_uint_t) v.audio_codec_id_n);
-    ngx_memcpy(ctx->profile, v.profile, sizeof(v.profile));
-    ngx_memcpy(ctx->level, v.level, sizeof(v.level));
+    if (v.profile[0] != '\0') ngx_memcpy(ctx->profile, v.profile, sizeof(v.profile));
+    if (v.level[0] != '\0') ngx_memcpy(ctx->level, v.level, sizeof(v.level));
 
     ngx_log_debug8(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
             "codec: data frame: "

--- a/ngx_rtmp_codec_module.c
+++ b/ngx_rtmp_codec_module.c
@@ -865,7 +865,7 @@ ngx_rtmp_codec_meta_data(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
     if (v.width != -1) ctx->width = (ngx_uint_t) v.width;
     if (v.height != -1) ctx->height = (ngx_uint_t) v.height;
     if (v.duration != -1) ctx->duration = (ngx_uint_t) v.duration;
-    if (v.frame_rate != -1) ctx->frame_rate = (ngx_uint_t) v.frame_rate;
+    if (v.frame_rate != -1) ctx->frame_rate = (double) v.frame_rate;
     if (v.video_data_rate != -1) ctx->video_data_rate = (ngx_uint_t) v.video_data_rate;
     if (v.video_codec_id_n != -1) ctx->video_codec_id = (ngx_uint_t) v.video_codec_id_n;
     if (v.audio_data_rate != -1) ctx->audio_data_rate = (ngx_uint_t) v.audio_data_rate;
@@ -874,7 +874,7 @@ ngx_rtmp_codec_meta_data(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
     if (v.profile[0] != '\0') ngx_memcpy(ctx->profile, v.profile, sizeof(v.profile));
     if (v.level[0] != '\0') ngx_memcpy(ctx->level, v.level, sizeof(v.level));
 
-    ngx_log_debug8(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
+    ngx_log_debug8(NGX_LOG_DEBUG, s->connection->log, 0,
             "codec: data frame: "
             "width=%ui height=%ui duration=%ui frame_rate=%ui "
             "video=%s (%ui) audio=%s (%ui)",

--- a/ngx_rtmp_codec_module.c
+++ b/ngx_rtmp_codec_module.c
@@ -864,7 +864,7 @@ ngx_rtmp_codec_meta_data(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
 
     if (v.width != -1) ctx->width = (ngx_uint_t) v.width;
     if (v.height != -1) ctx->height = (ngx_uint_t) v.height;
-    if (v.duration != -1) ctx->duration = (ngx_uint_t) v.duration;
+    if (v.duration != -1) ctx->duration = (double) v.duration;
     if (v.frame_rate != -1) ctx->frame_rate = (double) v.frame_rate;
     if (v.video_data_rate != -1) ctx->video_data_rate = (ngx_uint_t) v.video_data_rate;
     if (v.video_codec_id_n != -1) ctx->video_codec_id = (ngx_uint_t) v.video_codec_id_n;
@@ -876,7 +876,7 @@ ngx_rtmp_codec_meta_data(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
 
     ngx_log_debug8(NGX_LOG_DEBUG, s->connection->log, 0,
             "codec: data frame: "
-            "width=%ui height=%ui duration=%ui frame_rate=%ui "
+            "width=%ui height=%ui duration=%.3f frame_rate=%.3f "
             "video=%s (%ui) audio=%s (%ui)",
             ctx->width, ctx->height, ctx->duration, ctx->frame_rate,
             ngx_rtmp_get_video_codec_name(ctx->video_codec_id),

--- a/ngx_rtmp_codec_module.c
+++ b/ngx_rtmp_codec_module.c
@@ -866,9 +866,9 @@ ngx_rtmp_codec_meta_data(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h,
     if (v.height != -1) ctx->height = (ngx_uint_t) v.height;
     if (v.duration != -1) ctx->duration = (double) v.duration;
     if (v.frame_rate != -1) ctx->frame_rate = (double) v.frame_rate;
-    if (v.video_data_rate != -1) ctx->video_data_rate = (ngx_uint_t) v.video_data_rate;
+    if (v.video_data_rate != -1) ctx->video_data_rate = v.video_data_rate;
     if (v.video_codec_id_n != -1) ctx->video_codec_id = (ngx_uint_t) v.video_codec_id_n;
-    if (v.audio_data_rate != -1) ctx->audio_data_rate = (ngx_uint_t) v.audio_data_rate;
+    if (v.audio_data_rate != -1) ctx->audio_data_rate = v.audio_data_rate;
     if (v.audio_codec_id_n != -1) ctx->audio_codec_id = (v.audio_codec_id_n == 0
             ? NGX_RTMP_AUDIO_UNCOMPRESSED : (ngx_uint_t) v.audio_codec_id_n);
     if (v.profile[0] != '\0') ngx_memcpy(ctx->profile, v.profile, sizeof(v.profile));

--- a/ngx_rtmp_codec_module.h
+++ b/ngx_rtmp_codec_module.h
@@ -54,9 +54,9 @@ typedef struct {
     ngx_uint_t                  height;
     double                      duration;
     double                      frame_rate;
-    ngx_uint_t                  video_data_rate;
+    double                      video_data_rate;
     ngx_uint_t                  video_codec_id;
-    ngx_uint_t                  audio_data_rate;
+    double                      audio_data_rate;
     ngx_uint_t                  audio_codec_id;
     ngx_uint_t                  aac_profile;
     ngx_uint_t                  aac_chan_conf;

--- a/ngx_rtmp_codec_module.h
+++ b/ngx_rtmp_codec_module.h
@@ -52,8 +52,8 @@ u_char * ngx_rtmp_get_video_codec_name(ngx_uint_t id);
 typedef struct {
     ngx_uint_t                  width;
     ngx_uint_t                  height;
-    ngx_uint_t                  duration;
-    ngx_uint_t                  frame_rate;
+    double                      duration;
+    double                      frame_rate;
     ngx_uint_t                  video_data_rate;
     ngx_uint_t                  video_codec_id;
     ngx_uint_t                  audio_data_rate;


### PR DESCRIPTION
don't overwrite existing context metadata with invalid values
https://github.com/sergey-dryabzhinsky/nginx-rtmp-module/pull/8

Fixes for 42 frame rate not double
https://github.com/sergey-dryabzhinsky/nginx-rtmp-module/pull/45

Store audio and video bitrate in variables of type double
https://github.com/sergey-dryabzhinsky/nginx-rtmp-module/pull/77
